### PR TITLE
Fix multi wildcards

### DIFF
--- a/src/mime-types.ts
+++ b/src/mime-types.ts
@@ -226,7 +226,7 @@ class MimeTypes implements IMimeTypes {
 
     const escapeRE = (s: string) => s.replace(/[.+?^${}()|[\]\\]/g, "\\$&"); // escape regex specials
 
-    const pattern = "^" + escapeRE(type).replace("*", "[^/]*") + "$";
+    const pattern = "^" + escapeRE(type).replace(/\*/g, "[^\\/]*") + "$";
     const re = new RegExp(pattern);
 
     // Iterate 'types' map. In this repo 'types' maps ext -> mime (string or array)

--- a/test/1.cjs.spec.cjs
+++ b/test/1.cjs.spec.cjs
@@ -217,6 +217,58 @@ describe("MimeTypes CJS", function () {
       expect(exts.length).to.be.greaterThan(0);
     });
 
+    it("should support multiple wildcard mime types", function () {
+      const exts = MTypes.getExtensions("video/vnd.*.hd");
+      const deceVideoExts = MTypes.getExtensions("video/*.dece.*");
+      const deceImageExts = MTypes.getExtensions("image/*.dece.*");
+      const deceAudioExts = MTypes.getExtensions("audio/*.dece.*");
+      const deceAppExts = MTypes.getExtensions("application/*.dece.*");
+      const deceExts = MTypes.getExtensions("*/*.dece.*");
+
+      expect(exts).to.be.an("array");
+      expect(exts).to.include("uvh");
+      expect(exts).to.include("uvvh");
+      expect(exts.length).to.be.greaterThan(0);
+
+      const deceVideos = [
+        "uvh",
+        "uvp",
+        "uvs",
+        "uvv",
+        "uvm",
+        "uvvh",
+        "uvvp",
+        "uvvs",
+        "uvvv",
+        "uvvm",
+      ];
+      const deceImage = ["uvi", "uvg", "uvvi", "uvvg"];
+      const deceAudios = ["uva", "uvva"];
+      const deceApplication = [
+        "uvz",
+        "uvf",
+        "uvd",
+        "uvt",
+        "uvx",
+        "uvvz",
+        "uvvf",
+        "uvvd",
+        "uvvt",
+        "uvvx",
+      ];
+      const dece = [
+        ...deceVideos,
+        ...deceAudios,
+        ...deceApplication,
+        ...deceImage,
+      ];
+      assert.sameDeepMembers(deceVideoExts, deceVideos);
+      assert.sameDeepMembers(deceImageExts, deceImage);
+      assert.sameDeepMembers(deceAudioExts, deceAudios);
+      assert.sameDeepMembers(deceAppExts, deceApplication);
+      assert.sameDeepMembers(deceExts, dece);
+    });
+
     it("should normalize mime type (case + parameters)", function () {
       const exts = MTypes.getExtensions("IMAGE/JPEG; charset=utf-8");
       expect(exts).to.include("jpg");

--- a/test/2.destructured.spec.cjs
+++ b/test/2.destructured.spec.cjs
@@ -194,6 +194,58 @@ describe("MimeTypes CJS (Destructured)", function () {
       expect(exts.length).to.be.greaterThan(0);
     });
 
+    it("should support multiple wildcard mime types", function () {
+      const exts = getExtensions("video/vnd.*.hd");
+      const deceVideoExts = getExtensions("video/*.dece.*");
+      const deceImageExts = getExtensions("image/*.dece.*");
+      const deceAudioExts = getExtensions("audio/*.dece.*");
+      const deceAppExts = getExtensions("application/*.dece.*");
+      const deceExts = getExtensions("*/*.dece.*");
+
+      expect(exts).to.be.an("array");
+      expect(exts).to.include("uvh");
+      expect(exts).to.include("uvvh");
+      expect(exts.length).to.be.greaterThan(0);
+
+      const deceVideos = [
+        "uvh",
+        "uvp",
+        "uvs",
+        "uvv",
+        "uvm",
+        "uvvh",
+        "uvvp",
+        "uvvs",
+        "uvvv",
+        "uvvm",
+      ];
+      const deceImage = ["uvi", "uvg", "uvvi", "uvvg"];
+      const deceAudios = ["uva", "uvva"];
+      const deceApplication = [
+        "uvz",
+        "uvf",
+        "uvd",
+        "uvt",
+        "uvx",
+        "uvvz",
+        "uvvf",
+        "uvvd",
+        "uvvt",
+        "uvvx",
+      ];
+      const dece = [
+        ...deceVideos,
+        ...deceAudios,
+        ...deceApplication,
+        ...deceImage,
+      ];
+      assert.sameDeepMembers(deceVideoExts, deceVideos);
+      assert.sameDeepMembers(deceImageExts, deceImage);
+      assert.sameDeepMembers(deceAudioExts, deceAudios);
+      assert.sameDeepMembers(deceAppExts, deceApplication);
+      assert.sameDeepMembers(deceExts, dece);
+    });
+
     it("should normalize mime type (case + parameters)", function () {
       const exts = getExtensions("IMAGE/JPEG; charset=utf-8");
       expect(exts).to.include("jpg");

--- a/test/3.esm.spec.ts
+++ b/test/3.esm.spec.ts
@@ -224,6 +224,58 @@ describe("MimeTypes ESM", function () {
       expect(exts.length).to.be.greaterThan(0);
     });
 
+    it("should support multiple wildcard mime types", function () {
+      const exts = MTypes.getExtensions("video/vnd.*.hd");
+      const deceVideoExts = MTypes.getExtensions("video/*.dece.*");
+      const deceImageExts = MTypes.getExtensions("image/*.dece.*");
+      const deceAudioExts = MTypes.getExtensions("audio/*.dece.*");
+      const deceAppExts = MTypes.getExtensions("application/*.dece.*");
+      const deceExts = MTypes.getExtensions("*/*.dece.*");
+
+      expect(exts).to.be.an("array");
+      expect(exts).to.include("uvh");
+      expect(exts).to.include("uvvh");
+      expect(exts.length).to.be.greaterThan(0);
+
+      const deceVideos = [
+        "uvh",
+        "uvp",
+        "uvs",
+        "uvv",
+        "uvm",
+        "uvvh",
+        "uvvp",
+        "uvvs",
+        "uvvv",
+        "uvvm",
+      ];
+      const deceImage = ["uvi", "uvg", "uvvi", "uvvg"];
+      const deceAudios = ["uva", "uvva"];
+      const deceApplication = [
+        "uvz",
+        "uvf",
+        "uvd",
+        "uvt",
+        "uvx",
+        "uvvz",
+        "uvvf",
+        "uvvd",
+        "uvvt",
+        "uvvx",
+      ];
+      const dece = [
+        ...deceVideos,
+        ...deceAudios,
+        ...deceApplication,
+        ...deceImage,
+      ];
+      assert.sameDeepMembers(deceVideoExts, deceVideos);
+      assert.sameDeepMembers(deceImageExts, deceImage);
+      assert.sameDeepMembers(deceAudioExts, deceAudios);
+      assert.sameDeepMembers(deceAppExts, deceApplication);
+      assert.sameDeepMembers(deceExts, dece);
+    });
+
     it("should normalize mime type (case + parameters)", function () {
       const exts = MTypes.getExtensions("IMAGE/JPEG; charset=utf-8");
       expect(exts).to.include("jpg");

--- a/test/4.destructured.spec.ts
+++ b/test/4.destructured.spec.ts
@@ -201,6 +201,58 @@ describe("MimeTypes ESM (Destructured)", function () {
       expect(exts.length).to.be.greaterThan(0);
     });
 
+    it("should support multiple wildcard mime types", function () {
+      const exts = getExtensions("video/vnd.*.hd");
+      const deceVideoExts = getExtensions("video/*.dece.*");
+      const deceImageExts = getExtensions("image/*.dece.*");
+      const deceAudioExts = getExtensions("audio/*.dece.*");
+      const deceAppExts = getExtensions("application/*.dece.*");
+      const deceExts = getExtensions("*/*.dece.*");
+
+      expect(exts).to.be.an("array");
+      expect(exts).to.include("uvh");
+      expect(exts).to.include("uvvh");
+      expect(exts.length).to.be.greaterThan(0);
+
+      const deceVideos = [
+        "uvh",
+        "uvp",
+        "uvs",
+        "uvv",
+        "uvm",
+        "uvvh",
+        "uvvp",
+        "uvvs",
+        "uvvv",
+        "uvvm",
+      ];
+      const deceImage = ["uvi", "uvg", "uvvi", "uvvg"];
+      const deceAudios = ["uva", "uvva"];
+      const deceApplication = [
+        "uvz",
+        "uvf",
+        "uvd",
+        "uvt",
+        "uvx",
+        "uvvz",
+        "uvvf",
+        "uvvd",
+        "uvvt",
+        "uvvx",
+      ];
+      const dece = [
+        ...deceVideos,
+        ...deceAudios,
+        ...deceApplication,
+        ...deceImage,
+      ];
+      assert.sameDeepMembers(deceVideoExts, deceVideos);
+      assert.sameDeepMembers(deceImageExts, deceImage);
+      assert.sameDeepMembers(deceAudioExts, deceAudios);
+      assert.sameDeepMembers(deceAppExts, deceApplication);
+      assert.sameDeepMembers(deceExts, dece);
+    });
+
     it("should normalize mime type (case + parameters)", function () {
       const exts = getExtensions("IMAGE/JPEG; charset=utf-8");
       expect(exts).to.include("jpg");


### PR DESCRIPTION
Updated the regex pattern to correctly handle multiple wildcards in MIME type matching by replacing all '*' characters with the appropriate regex expression.